### PR TITLE
Remove copyright from sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -25,9 +25,6 @@
           {% endif %}
         {% endif %}
       {% endfor %}
-      <span class="sidebar-nav-item">Made with Jekyll using <a href="https://github.com/poole/hyde">Hyde</a></span>
     </nav>
-
-    <p>&copy; {{ site.time | date: '%Y' }}. All rights reserved.</p>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,10 @@
 
     <div class="content container">
       {{ content }}
+      <p class="content-footer">
+        Made with Jekyll using <a href="https://github.com/poole/hyde">Hyde</a><br>
+        &copy; {{ site.time | date: '%Y' }}. All rights reserved.
+      </p>
     </div>
 
   </body>

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -23,3 +23,16 @@ html {
  .pagination {
     font-family: "Roboto-Condensed", Helvetica, Arial, sans-serif;
   }
+
+/* Sidebar nav footer */
+.content-footer {
+    display: block;
+    line-height: 1.75;
+    font-size: 0.8rem;
+    max-width: 38rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+}

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -24,7 +24,7 @@ html {
     font-family: "Roboto-Condensed", Helvetica, Arial, sans-serif;
   }
 
-/* Sidebar nav footer */
+/* Content footer for Copyright and Attribution */
 .content-footer {
     display: block;
     line-height: 1.75;


### PR DESCRIPTION
Fixes #30 

- Removing the copy right from the sidebar and below the content