### PR TITLE
Update gitignore to handle node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+/node_modules


### PR DESCRIPTION
Fixes #37 

- Adding the famous node_modules to the .gitignore